### PR TITLE
fix nested map serialization

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/MapWriteContext.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/MapWriteContext.java
@@ -46,7 +46,7 @@ public final class MapWriteContext
     public final AvroWriteContext createChildObjectContext() throws JsonMappingException
     {
         _verifyValueWrite();
-        AvroWriteContext child = _createObjectContext(_schema.getElementType());
+        AvroWriteContext child = _createObjectContext(_schema.getValueType());
         _data.put(_currentName, child.rawValue());
         return child;
     }

--- a/src/test/java/com/fasterxml/jackson/dataformat/avro/NestedMapTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/avro/NestedMapTest.java
@@ -1,0 +1,52 @@
+package fasterxml.jackson.dataformat.avro;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.avro.Schema;
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.avro.AvroMapper;
+import com.fasterxml.jackson.dataformat.avro.AvroSchema;
+import com.fasterxml.jackson.dataformat.avro.schema.AvroSchemaGenerator;
+
+
+public class NestedMapTest {
+	
+	public static class Nester {
+		@JsonProperty
+		public Map<String,Map<String,Integer>> nested;
+	}
+	
+	@Test
+	public void testSerialization() throws IOException {
+
+
+		Nester fromJson = new ObjectMapper().readValue(
+				"{\"nested\": {\"map\":{\"value\":1}}}"
+				, Nester.class);
+		
+		AvroMapper mapper = new AvroMapper();
+		//Generate schema from class
+		AvroSchemaGenerator gen = new AvroSchemaGenerator();
+		mapper.acceptJsonFormatVisitor(Nester.class, gen);
+		Schema schema = gen.getGeneratedSchema().getAvroSchema(); 
+		
+		
+		//Serialize
+		byte[] avroData =  mapper.writer(new AvroSchema(schema))
+				.writeValueAsBytes(fromJson);
+
+		//Deserialize
+		Nester nester = mapper.readerFor(Nester.class)
+				   .with(new AvroSchema(schema))
+				   .readValue(avroData);
+		int val = nester.nested.get("map").get("value");
+		assertEquals(1, val);
+		
+	}
+}


### PR DESCRIPTION
With current version, attempting to serialize with a schema that has any nested maps results in a JsonMappingException along the lines of: Not an array: {"type":"map","values":...

Fix is simple, looks like it was just a typo.