### PR TITLE
support serialization of BigDecimal values

### DIFF
--- a/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/NonBSGenericDatumWriter.java
+++ b/src/main/java/com/fasterxml/jackson/dataformat/avro/ser/NonBSGenericDatumWriter.java
@@ -1,10 +1,13 @@
 package com.fasterxml.jackson.dataformat.avro.ser;
 
+import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.List;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.Encoder;
 
 /**
  * Need to sub-class to prevent encoder from crapping on writing an optional
@@ -36,8 +39,27 @@ public class NonBSGenericDatumWriter<D>
 				default:
 				}
 			}
+		} else if( datum instanceof BigDecimal) {
+			List<Schema> schemas = union.getTypes();
+			for (int i = 0, len = schemas.size(); i < len; ++i) {
+				Schema s = schemas.get(i);
+				switch (s.getType()) {
+				case DOUBLE:
+					return i;
+				default:
+				}
+			}
 		}
 		// otherwise just default to base impl, stupid as it is...
 		return super.resolveUnion(union, datum);
+	}
+
+	@Override
+	protected void write(Schema schema, Object datum, Encoder out) throws IOException {
+		if(schema.getType() == Type.DOUBLE && datum instanceof BigDecimal) {
+			out.writeDouble(((BigDecimal)datum).doubleValue());
+		} else {
+			super.write(schema, datum, out);
+		}
 	}
 }

--- a/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimalTest.java
+++ b/src/test/java/com/fasterxml/jackson/dataformat/avro/BigDecimalTest.java
@@ -1,0 +1,40 @@
+package com.fasterxml.jackson.dataformat.avro;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+
+public class BigDecimalTest extends TestCase {
+
+    @Test
+    public void testSSerializeBigDecimal() throws Exception {
+        AvroMapper mapper = new AvroMapper();
+        AvroSchema schema = mapper.schemaFor(NamedAmount.class);
+
+        byte[] bytes = mapper.writer(schema)
+                .writeValueAsBytes(new NamedAmount("peter", 42.0));
+
+        NamedAmount result = mapper.reader(schema).forType(NamedAmount.class).readValue(bytes);
+
+        assertEquals("peter", result.name);
+        assertEquals(BigDecimal.valueOf(42.0), result.amount);
+    }
+
+    public static class NamedAmount {
+        public final String name;
+        public final BigDecimal amount;
+
+        @JsonCreator
+        public NamedAmount(@JsonProperty("name") String name,
+                           @JsonProperty("amount") double amount) {
+            this.name = name;
+            this.amount = BigDecimal.valueOf(amount);
+        }
+
+
+    }
+}


### PR DESCRIPTION
Avro doesn't have direct support for BigDecimal. Since jackson's schema generation considers them a double, translate values to a double prior to serialization.

Deserialization does not currently work since jackson wants to read the value as a string and use the BigDecimal(String) constructor. 